### PR TITLE
fix bug in eval_pose mode

### DIFF
--- a/utils/vis_utils.py
+++ b/utils/vis_utils.py
@@ -184,11 +184,11 @@ plt.rc('legend', fontsize=20)  # using a named size
 
 
 def plot_pose(ref_poses, est_poses, output_path, vid=False):
-    ref_poses = [pose for pose in ref_poses]
+    ref_poses = [pose.numpy() for pose in ref_poses]
     if isinstance(est_poses, dict):
-        est_poses = [pose for k, pose in est_poses.items()]
+        est_poses = [pose.numpy() for k, pose in est_poses.items()]
     else:
-        est_poses = [pose for pose in est_poses]
+        est_poses = [pose.numpy() for pose in est_poses]
     traj_ref = PosePath3D(poses_se3=ref_poses)
     traj_est = PosePath3D(poses_se3=est_poses)
     traj_est_aligned = copy.deepcopy(traj_est)


### PR DESCRIPTION
Hi, I find a bug when performing the `eval_pose mode` by command
```
python run_cf3dgs.py --source data/Tanks/Francis \
                     --mode eval_pose \
                     --data_type tanks \
                     --model_path ./output/progressive/Tanks_Francis/chkpnt/ep00_init.pth
```
The error is due to directly evaluating the pose in Pytorch.Tensor, which should be Numpy.Array, in:
```
File "/code/CF-3DGS/utils/vis_utils.py", line 196, in plot_pose
    traj_est_aligned.align(traj_ref, correct_scale=True,
```
I have fixed and tested the code.